### PR TITLE
Back Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "framer-motion": "^10.16.16",
         "next": "14.0.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^4.12.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.0.1",
@@ -1391,6 +1392,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "framer-motion": "^10.16.16",
     "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^4.12.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.0.1",

--- a/src/app/challenges/blog-preview-card/page.jsx
+++ b/src/app/challenges/blog-preview-card/page.jsx
@@ -4,9 +4,13 @@
 import Image from "next/image"
 import { motion } from "framer-motion"
 
+// Components
+import Back from "@/components/master/utils/Back"
+
 export default function about() {
     return (
         <main className="flex bg-bpc-yellow min-w-full min-h-screen justify-center items-center">
+            <Back></Back>
             <motion.div initial={{scale: 0}} animate={{scale: 1}} transition={{duration: 0.4}} className="flex ml-6 mr-6 p-6 gap-6 flex-col w-[384px] rounded-xl bg-bpc-pure-white outline outline-2h outline-bpc-black shadow-[12px_10px_0_1px_rgba(0,0,0,100)]">
                 <Image className="w-full rounded-xl" src={'/blog-preview-card/illustration-article.svg'} width={300} height={150}></Image>
                 <div className="flex flex-col min-w-full gap-3">

--- a/src/components/master/utils/Back.jsx
+++ b/src/components/master/utils/Back.jsx
@@ -1,0 +1,21 @@
+// Imports
+import Link from "next/link";
+
+// Icons
+import { FaArrowCircleLeft } from "react-icons/fa";
+import { SiFrontendmentor } from "react-icons/si";
+import { FaGithub } from "react-icons/fa";
+
+export default function Back() {
+    return (
+        <div className="absolute left-8 top-8 text-center">
+            <div className="flex flex-row gap-7 items-center w-fit rounded-full ml-auto mr-auto justify-center">
+                <Link href={'/'}><FaArrowCircleLeft className="scale-[2] text-black cursor-pointer opacity-20 hover:opacity-100 duration-200" /></Link>
+                <a target="_blank" href="https://www.frontendmentor.io/profile/joshpickardme"><SiFrontendmentor className="scale-[2] text-black cursor-pointer opacity-20 hover:opacity-100 duration-200" /></a>
+                <a target="_blank" href="https://github.com/joshpickardme"><FaGithub className="scale-[2] text-black cursor-pointer opacity-20 hover:opacity-100 duration-200" /></a>
+            </div>
+            
+        </div>
+        
+    )
+}


### PR DESCRIPTION
## Description
Back menu component which includes:

- [x] Link back to the challenges page
- [x] Link to my Frontend Mentor page
- [x] Link to my GitHub profile

The design is low opacity by default to avoid it getting in the way of the main design of the challenge. Once the user hovers over it, it makes the icon more visible.

closes #4 